### PR TITLE
Implement batch-based translation structure

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -82,6 +82,12 @@ def parse_args():
         "--languages",
         required=True,
         help="list of language codes")
+    parser.add_argument(
+        '--batch-size',
+        type=int,
+        default=5,
+        help='Number of entries to translate in one batch (default: 5)'
+    )
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Related Issue
- #32
- #42 

## Category
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Description
기존의 **entry 단위 번역 구조**를 개선해 **batch 기반 번역 구조**로 변경한 리팩토링입니다.

주요 변경 사항은 아래와 같습니다.
    1. translate_entry() -> translate_batch() 구조로 변경
    2. 여러 msgid를 하나의 batch로 묶어 AI에 전달하도록 개선
    3. Glossary 및 Few-shot 적용 로직을 batch 처리 방식에 맞게 변경
    4. utils.py 내 함수 인자 추가(batch_size)

## 테스트 결과
    1. i18n-docs-source-locale.pot 파일 기준 정상 번역 완료
    2. batch로 구조 개편 후 성능 비교
        **기존**: Avg=0.7937 | Med=0.8592 | ≥0.8 = 62.41%
        **변경 후**: Avg=0.8554 | Med=0.8917 | ≥0.8 = 76.77%
        => 이전 구조 대비 번역 속도는 유사하나, 품질 측면에서 많이 개선됨을 확인할 수 있습니다.
<img width="2164" height="214" alt="quality check" src="https://github.com/user-attachments/assets/49db96d3-7367-448f-9b33-1846d4facd68" />
