### PR TITLE
Feat/update translate pipeline

### DIFF
--- a/ci/playbooks/roles/prepare-ai-translation/defaults/main.yaml
+++ b/ci/playbooks/roles/prepare-ai-translation/defaults/main.yaml
@@ -74,7 +74,6 @@ ai_config:
   files:
     pot_file: "{{ project_name | replace('-', '_') }}.pot"
     glossary_po: "glossary.po"
-    glossary_json: "glossary.json"
     example_file: "nova-nova-locale.po"
     fixed_json: "fixed_examples.json"
 

--- a/ci/playbooks/roles/prepare-ai-translation/files/translate.py
+++ b/ci/playbooks/roles/prepare-ai-translation/files/translate.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""AI translation pipeline for OpenStack i18n.
+
+Translates POT files into multiple languages using LLM models
+with glossary-based consistency and parallel batch processing.
+
+Execution flow:
+    1. Load config and initialize utilities
+    2. For each target language:
+       a. Load glossary and few-shot examples
+       b. Translate POT entries in parallel batches
+       c. Save PO file and experiment log
+"""
+
+import os
+import time
+import concurrent.futures
+import json
+import argparse
+from dataclasses import dataclass
+
+import ollama
+from tqdm import tqdm
+from babel import Locale
+from babel.messages import pofile, Catalog
+
+from utils import ResourceLoader, load_config, save_experiment_log, logger
+
+
+def get_language_name(lang_code):
+    """Resolve a language code to its full English display name.
+
+    Returns:
+        Full language name (e.g., 'Korean (South Korea)'),
+        or lang_code as-is if unrecognized.
+    """
+    try:
+        return Locale.parse(lang_code).get_display_name('en')
+    except Exception:
+        return lang_code
+
+
+PROMPT_DIR = os.path.join(os.path.dirname(__file__), "prompts")
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a strict translation engine.\n"
+    "You are translating from English to {language_name}.\n"
+    "\n"
+    "[Output Format Rules (MUST Follow)]\n"
+    "* Respond ONLY with the raw, translated text for {language_name}.\n"
+    "* Your answer MUST be 100% in {language_name}.\n"
+    "* Do NOT mix in any other languages (including English).\n"
+    "* Do NOT add explanations, comments, apologies, or quotes.\n"
+    "\n"
+    "[Critical Preservation Rules (MUST Follow)]\n"
+    "* Preserve all reStructuredText (RST) syntax exactly.\n"
+    "* Preserve all placeholders exactly.\n"
+    "* Preserve all HTML tags exactly.\n"
+    "* You MUST use the exact translations provided in the "
+    "`[Glossary]` section.\n"
+    "\n"
+    "[Anti-Hallucination Rules (MUST Follow)]\n"
+    "* You MUST NOT add placeholders that are NOT in the original `msgid`.\n"
+    "* You MUST NOT repeat phrases. Repetition is strictly forbidden.\n"
+    "\n"
+    "[Glossary]\n"
+)
+
+
+@dataclass
+class TranslationContext:
+    glossary: dict
+    few_shot_examples: list
+    call_llm_fn: object
+    max_workers: int
+    system_prompt: str
+
+
+class AITranslator:
+    @staticmethod
+    def build_llm_caller(model_name):
+        """Build an Ollama-based LLM caller function.
+
+        Forces the model to respond with a JSON array of strings
+        using a structured output schema.
+
+        Returns a callable that accepts a message list and returns
+        the model's response text.
+        """
+        _response_format = {"type": "array", "items": {"type": "string"}}
+
+        def _call(messages):
+            response = ollama.chat(
+                model=model_name,
+                messages=messages,
+                stream=False,
+                format=_response_format,
+                options={
+                    "temperature": 0,
+                    "top_p": 1,
+                    "repetition_penalty": 1.2,
+                },
+            )
+            return response["message"]["content"].strip()
+
+        return _call
+
+    @staticmethod
+    def create_batches(entries, batch_size):
+        return [
+            entries[i:i + batch_size]
+            for i in range(0, len(entries), batch_size)
+        ]
+
+    def _retry_individually(self, entries, batch_idx, total_batches,
+                            language_name, ctx):
+        """Retry failed batch entries one by one."""
+        logger.warning(
+            f"[Batch {batch_idx + 1}/{total_batches}] "
+            "Retrying entries one by one...")
+        results = []
+        for entry in entries:
+            results.extend(self.translate_batch(
+                [entry], batch_idx, total_batches,
+                language_name, ctx, is_fallback=True))
+        return results
+
+    def translate_batch(self, entries, batch_idx, total_batches,
+                        language_name, ctx, is_fallback=False):
+        """Translate a batch of PO entries using the LLM.
+
+        On count mismatch or error, retries each entry individually
+        unless is_fallback=True, in which case returns empty strings.
+
+        Args:
+            entries: List of PO entries to translate.
+            batch_idx: Index of the current batch (0-based).
+            total_batches: Total number of batches.
+            language_name: Full language name for the prompt.
+            ctx: TranslationContext with glossary, examples, etc.
+            is_fallback: If True, skip individual retry on failure.
+
+        Returns:
+            list: [(msgid, translation, locations), ...].
+                On error with is_fallback=True, translation is empty string.
+        """
+
+        glossary_text = "\n".join(
+            f"* '{en}': '{translated}'"
+            for en, translated in ctx.glossary.items())
+        system_prompt = ctx.system_prompt + glossary_text
+
+        messages = [
+            {
+                "role": "system",
+                "content": system_prompt.format(language_name=language_name),
+            },
+        ]
+
+        # Add few-shot examples
+        few_shot_inputs = [msgid for msgid, _ in ctx.few_shot_examples]
+        few_shot_outputs = [msgstr for _, msgstr in ctx.few_shot_examples]
+
+        messages.append({
+            "role": "user",
+            "content": (
+                "Here are examples of translating a JSON array:\n"
+                f"{json.dumps(few_shot_inputs, ensure_ascii=False)}"
+            )
+        })
+        messages.append({
+            "role": "assistant",
+            "content": json.dumps(few_shot_outputs, ensure_ascii=False)
+        })
+
+        # Build translation request
+        texts_to_translate = [entry.id for entry in entries]
+        user_content = (
+            f"Translate the following {len(texts_to_translate)} items.\n"
+            "Your response MUST be a single, valid JSON array `[...]` "
+            f"containing exactly {len(texts_to_translate)} "
+            "translated strings in the same order."
+            "Do NOT add any other text, explanations, "
+            "or markdown formatting.\n\n"
+            f"{json.dumps(texts_to_translate, ensure_ascii=False)}")
+
+        messages.append({"role": "user", "content": user_content})
+
+        # Call LLM and parse response
+        try:
+            translations = json.loads(ctx.call_llm_fn(messages))
+
+            if not isinstance(translations, list):
+                raise ValueError(
+                    f"Expected JSON array, got {type(translations).__name__}")
+
+            if len(translations) != len(entries):
+                logger.warning(
+                    f"[Batch {batch_idx + 1}/{total_batches}] "
+                    "Translation count mismatch: "
+                    f"expected {len(entries)}, got {len(translations)}")
+                if is_fallback:
+                    return [(entry.id, "", entry.locations)
+                            for entry in entries]
+                return self._retry_individually(
+                    entries, batch_idx, total_batches, language_name, ctx)
+
+            return [
+                (entry.id, translation.strip().rstrip(']"').strip(),
+                 entry.locations)
+                for entry, translation in zip(entries, translations)
+            ]
+
+        except Exception as e:
+            logger.error(
+                f"[Batch {batch_idx + 1}/{total_batches}] "
+                f"Error translating batch: {e}")
+            if is_fallback:
+                return [(entry.id, "", entry.locations) for entry in entries]
+            return self._retry_individually(
+                entries, batch_idx, total_batches, language_name, ctx)
+
+    def translate_pot_file(self, pot_path, po_path, language_code,
+                           language_name, batch_size, ctx):
+        """Translate a POT file and save as PO.
+
+        Reads entries from the POT file, translates them in parallel
+        batches, and writes the results to a PO file.
+
+        Args:
+            pot_path: Path to the source POT file.
+            po_path: Path to save the translated PO file.
+            language_code: Target language code (e.g., 'ko_KR').
+            language_name: Full language name for prompts.
+            batch_size: Number of entries per translation batch.
+            ctx: TranslationContext with glossary, examples, etc.
+        """
+        with open(pot_path, "rb") as f:
+            pot = pofile.read_po(f)
+
+        po = Catalog(
+            locale=language_code,
+            project=pot.project,
+            version=pot.version,
+            copyright_holder=pot.copyright_holder,
+            msgid_bugs_address=pot.msgid_bugs_address,
+            creation_date=pot.creation_date,
+            language_team=pot.language_team,
+            charset="UTF-8",
+        )
+
+        entries_to_translate = [entry for entry in pot if entry.id]
+        total_entries = len(entries_to_translate)
+
+        batches = self.create_batches(entries_to_translate, batch_size)
+        total_batches = len(batches)
+
+        logger.info(
+            f"--- Translating {os.path.basename(pot_path)} "
+            f"to {language_code} ---")
+        logger.info(
+            f"Total {total_entries} entries in {total_batches} batches "
+            f"(batch_size: {batch_size}, workers: {ctx.max_workers})")
+
+        # Translate in parallel
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=ctx.max_workers
+        ) as executor:
+            results = list(
+                tqdm(
+                    executor.map(
+                        lambda args: self.translate_batch(
+                            *args, language_name, ctx),
+                        [(batch, i, total_batches)
+                         for i, batch in enumerate(batches)]),
+                    total=total_batches,
+                    desc=f"Translating batches [{language_code}]",
+                    unit="batch",
+                ))
+
+        for batch_result in results:
+            for msgid, translation, locations in batch_result:
+                po.add(
+                    id=msgid, string=translation,
+                    locations=locations,
+                    user_comments=["Initial translation by AI."])
+
+        try:
+            with open(po_path, "wb") as f:
+                pofile.write_po(f, po)
+            logger.info(f"Saved: {po_path}")
+        except Exception as e:
+            logger.error(f"Failed to save PO file: {e}")
+
+    def translate_language(self, lang_code, pot_path, po_filename,
+                           config, resources, call_llm_fn):
+        """Run the full translation pipeline for a single language.
+
+        Loads glossary, few-shot examples, and system prompt, then
+        translates the POT file and saves the experiment log.
+
+        Args:
+            lang_code: Target language code (e.g., 'ko_KR').
+            pot_path: Path to the source POT file.
+            po_filename: Output PO filename (e.g., 'neutron_lib.po').
+            config: Parsed config dictionary.
+            resources: ResourceLoader instance.
+            call_llm_fn: LLM caller function.
+        """
+        lang_start_time = time.time()
+        logger.info(f"--- [{lang_code}] Translation start ---")
+
+        language_name = get_language_name(lang_code)
+
+        glossary = resources.load_glossary(
+            lang_code,
+            glossary_dir=config['paths']['glossary_dir'],
+            glossary_po_file=config['files']['glossary_po'],
+        )
+        few_shot_examples = resources.load_fixed_examples(
+            lang_code,
+            config['paths']['example_dir'],
+            config['files']['fixed_json'],
+            config['urls']['example'],
+            config['files']['example_file'],
+        )
+
+        system_prompt = resources.load_support_prompt(lang_code)
+        if system_prompt:
+            logger.info(f"Using custom support prompt for {lang_code}")
+        else:
+            system_prompt = DEFAULT_SYSTEM_PROMPT
+
+        ctx = TranslationContext(
+            glossary=glossary,
+            few_shot_examples=few_shot_examples,
+            call_llm_fn=call_llm_fn,
+            max_workers=config['ai']['workers'],
+            system_prompt=system_prompt,
+        )
+
+        model = config['ai']['model']
+        po_file_path = os.path.join(
+            config['paths']['po_dir'], model, lang_code, po_filename)
+        os.makedirs(os.path.dirname(po_file_path), exist_ok=True)
+
+        self.translate_pot_file(
+            pot_path, po_file_path,
+            lang_code, language_name,
+            config['ai']['batch_size'], ctx,
+        )
+
+        lang_duration = round(time.time() - lang_start_time, 2)
+        logger.info(
+            f"--- [{lang_code}] Translation end ({lang_duration}s) ---")
+
+        save_experiment_log(
+            model_name=model,
+            pot_file=pot_path,
+            po_file=po_file_path,
+            duration_sec=lang_duration,
+            language=lang_code,
+            results_csv_path=os.path.join(
+                config['paths']['output_dir'], "experiments.csv"),
+        )
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description="Run AI translation pipeline")
+    parser.add_argument(
+        "--config", default="config.yaml",
+        help="Path to config YAML file (default: config.yaml)")
+    return parser.parse_args()
+
+
+def main():
+    config = load_config(get_args().config)
+
+    model = config['ai']['model']
+    pot_path = os.path.join(
+        config['paths']['pot_dir'], config['files']['pot_file'])
+
+    if not os.path.exists(pot_path):
+        raise FileNotFoundError(f"POT file not found: {pot_path}")
+
+    po_filename = os.path.basename(pot_path).replace(".pot", ".po")
+    resources = ResourceLoader(
+        glossary_url=config['urls']['glossary'], prompt_dir=PROMPT_DIR)
+    translator = AITranslator()
+    call_llm_fn = AITranslator.build_llm_caller(model)
+
+    logger.info(
+        f"--- Translation Start | LLM: {model} "
+        f"| Batch Size: {config['ai']['batch_size']} ---")
+
+    start_time = time.time()
+    for lang_code in config['languages']:
+        translator.translate_language(
+            lang_code, pot_path, po_filename, config, resources, call_llm_fn)
+
+    logger.info(
+        f"Total translation time: {round(time.time() - start_time, 2)}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/playbooks/roles/prepare-ai-translation/files/translate.py
+++ b/ci/playbooks/roles/prepare-ai-translation/files/translate.py
@@ -24,7 +24,7 @@ from tqdm import tqdm
 from babel import Locale
 from babel.messages import pofile, Catalog
 
-from utils import ResourceLoader, load_config, save_experiment_log, logger
+from utils import ResourceLoader, load_config, logger
 
 
 def get_language_name(lang_code):
@@ -353,16 +353,6 @@ class AITranslator:
         lang_duration = round(time.time() - lang_start_time, 2)
         logger.info(
             f"--- [{lang_code}] Translation end ({lang_duration}s) ---")
-
-        save_experiment_log(
-            model_name=model,
-            pot_file=pot_path,
-            po_file=po_file_path,
-            duration_sec=lang_duration,
-            language=lang_code,
-            results_csv_path=os.path.join(
-                config['paths']['output_dir'], "experiments.csv"),
-        )
 
 
 def get_args():

--- a/ci/playbooks/roles/prepare-ai-translation/files/utils.py
+++ b/ci/playbooks/roles/prepare-ai-translation/files/utils.py
@@ -1,16 +1,13 @@
 """Shared utilities for the AI translation pipeline.
 
 Provides configuration loading, logging setup, module name resolution,
-glossary/example loading, and experiment logging used across scripts.
+and glossary/example loading used across scripts.
 """
 import os
 import json
-import csv
-import subprocess
 import configparser
 import re
 import logging
-from datetime import datetime
 
 import requests
 import yaml
@@ -77,64 +74,6 @@ def get_modulename(project_dir, project):
                 return packages[0]
 
     return project
-
-
-def save_experiment_log(model_name, pot_file, po_file,
-                        duration_sec, language, accuracy=None,
-                        results_csv_path="./experiments.csv"):
-    """Append experiment results to a CSV log file.
-
-    Records translation run metadata including model, duration,
-    language, and git information.
-
-    Args:
-        model_name: LLM model name used for translation.
-        pot_file: Path to the source POT file.
-        po_file: Path to the generated PO file.
-        duration_sec: Translation duration in seconds.
-        language: Target language code.
-        accuracy: Optional translation accuracy score.
-        results_csv_path: Path to the CSV log file.
-    """
-    def _run_git(*args):
-        try:
-            return subprocess.check_output(
-                ["git", *args], stderr=subprocess.DEVNULL
-            ).decode().strip()
-        except Exception:
-            return None
-
-    git_commit = _run_git("rev-parse", "HEAD")
-    git_branch = _run_git("rev-parse", "--abbrev-ref", "HEAD")
-
-    result_entry = {
-        "timestamp": datetime.now().isoformat(timespec="seconds"),
-        "model": model_name,
-        "pot_file": os.path.abspath(pot_file),
-        "po_file": os.path.abspath(po_file),
-        "duration_sec": duration_sec,
-        "language": language,
-        "accuracy": accuracy,
-        "git_commit": git_commit,
-        "git_branch": git_branch,
-    }
-
-    try:
-        file_exists = os.path.exists(results_csv_path)
-        with open(results_csv_path,
-                  "a",
-                  newline="",
-                  encoding="utf-8") as csvfile:
-            writer = csv.DictWriter(
-                csvfile, fieldnames=list(result_entry.keys()))
-
-            if not file_exists:
-                writer.writeheader()
-            writer.writerow(result_entry)
-
-        logger.info(f"Experiment log saved to: {results_csv_path}")
-    except Exception as e:
-        logger.warning(f"Failed to save experiment log: {e}")
 
 
 class ResourceLoader:

--- a/ci/playbooks/roles/prepare-ai-translation/files/utils.py
+++ b/ci/playbooks/roles/prepare-ai-translation/files/utils.py
@@ -1,10 +1,20 @@
-"""Shared utilities for the AI translation pipeline."""
+"""Shared utilities for the AI translation pipeline.
+
+Provides configuration loading, logging setup, module name resolution,
+glossary/example loading, and experiment logging used across scripts.
+"""
 import os
+import json
+import csv
+import subprocess
 import configparser
 import re
 import logging
+from datetime import datetime
 
+import requests
 import yaml
+from babel.messages import pofile
 
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
@@ -42,20 +52,16 @@ def get_modulename(project_dir, project):
         parser = configparser.ConfigParser()
         parser.read(setup_cfg)
 
-        if parser.has_option("openstack_translations", "python_modules"):
-            modules = [
-                m.strip() for m in parser.get(
-                    "openstack_translations",
-                    "python_modules").split("\n") if m.strip()]
-            if modules:
-                return modules[0]
-
-        if parser.has_option("files", "packages"):
-            modules = [m.strip() for m in
-                       parser.get("files", "packages").split("\n")
-                       if m.strip()]
-            if modules:
-                return modules[0]
+        for section, option in [
+            ("openstack_translations", "python_modules"),
+            ("files", "packages"),
+        ]:
+            if parser.has_option(section, option):
+                modules = [m.strip() for m in
+                           parser.get(section, option).split("\n")
+                           if m.strip()]
+                if modules:
+                    return modules[0]
 
     pyproject = os.path.join(project_dir, "pyproject.toml")
     if os.path.isfile(pyproject):
@@ -71,3 +77,234 @@ def get_modulename(project_dir, project):
                 return packages[0]
 
     return project
+
+
+def save_experiment_log(model_name, pot_file, po_file,
+                        duration_sec, language, accuracy=None,
+                        results_csv_path="./experiments.csv"):
+    """Append experiment results to a CSV log file.
+
+    Records translation run metadata including model, duration,
+    language, and git information.
+
+    Args:
+        model_name: LLM model name used for translation.
+        pot_file: Path to the source POT file.
+        po_file: Path to the generated PO file.
+        duration_sec: Translation duration in seconds.
+        language: Target language code.
+        accuracy: Optional translation accuracy score.
+        results_csv_path: Path to the CSV log file.
+    """
+    def _run_git(*args):
+        try:
+            return subprocess.check_output(
+                ["git", *args], stderr=subprocess.DEVNULL
+            ).decode().strip()
+        except Exception:
+            return None
+
+    git_commit = _run_git("rev-parse", "HEAD")
+    git_branch = _run_git("rev-parse", "--abbrev-ref", "HEAD")
+
+    result_entry = {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "model": model_name,
+        "pot_file": os.path.abspath(pot_file),
+        "po_file": os.path.abspath(po_file),
+        "duration_sec": duration_sec,
+        "language": language,
+        "accuracy": accuracy,
+        "git_commit": git_commit,
+        "git_branch": git_branch,
+    }
+
+    try:
+        file_exists = os.path.exists(results_csv_path)
+        with open(results_csv_path,
+                  "a",
+                  newline="",
+                  encoding="utf-8") as csvfile:
+            writer = csv.DictWriter(
+                csvfile, fieldnames=list(result_entry.keys()))
+
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(result_entry)
+
+        logger.info(f"Experiment log saved to: {results_csv_path}")
+    except Exception as e:
+        logger.warning(f"Failed to save experiment log: {e}")
+
+
+class ResourceLoader:
+    def __init__(self, glossary_url=None, prompt_dir=None):
+        self.glossary_url = glossary_url
+        self.prompt_dir = prompt_dir
+
+    def _download_file(self, url, dest_path, label):
+        """Download a file from URL and save to dest_path.
+
+        Args:
+            url: URL to download from.
+            dest_path: Local path to save the downloaded file.
+            label: Human-readable description used in log messages.
+
+        Returns:
+            bool: True on success, False on failure.
+        """
+        logger.info(f"Downloading {label} from {url}...")
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            with open(dest_path, "wb") as f:
+                f.write(response.content)
+            logger.info(
+                f"Successfully downloaded and saved to {dest_path}")
+            return True
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Could not download {label}: {e}")
+            return False
+
+    def load_support_prompt(self, language_code):
+        """Load a language-specific custom prompt if available."""
+        if not self.prompt_dir:
+            return None
+        prompt_path = os.path.join(self.prompt_dir, f"{language_code}.txt")
+        if os.path.isfile(prompt_path):
+            with open(prompt_path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+        return None
+
+    def load_glossary(self, lang, glossary_dir,
+                      glossary_po_file="glossary.po"):
+        """Download/load a glossary PO file.
+
+        Args:
+            lang: Language code to process.
+            glossary_dir: Root directory for glossary files.
+            glossary_po_file: Glossary PO filename.
+
+        Returns:
+            dict: Glossary mapping (English term -> translated term).
+        """
+        lang_dir = os.path.join(glossary_dir, lang)
+        os.makedirs(lang_dir, exist_ok=True)
+
+        glossary_po_path = os.path.join(lang_dir, glossary_po_file)
+
+        if not os.path.exists(glossary_po_path):
+            if not self._download_file(
+                    self.glossary_url.format(lang=lang),
+                    glossary_po_path,
+                    f"glossary for [{lang}]"):
+                return {}
+
+        logger.info(f"Building glossary for [{lang}]...")
+        try:
+            with open(glossary_po_path, "rb") as f:
+                glossary_po = pofile.read_po(f)
+            glossary = {
+                entry.id.strip().lower(): entry.string.strip()
+                for entry in glossary_po
+                if entry.id and entry.string
+            }
+            logger.info(
+                f"Glossary for [{lang}] loaded "
+                f"with {len(glossary)} terms.")
+            return glossary
+        except Exception as e:
+            logger.error(
+                f"Error reading Glossary PO file for [{lang}]: {e}")
+            return {}
+
+    def load_examples(self, lang, url_template, example_file, example_dir):
+        """Download/load a language-specific example PO file.
+
+        Args:
+            lang: Language code to process.
+            url_template: URL template for downloading the PO file.
+            example_file: Example PO filename.
+            example_dir: Root directory for example files.
+
+        Returns:
+            list: List of (msgid, msgstr) tuples.
+        """
+        if not url_template:
+            return []
+
+        lang_dir = os.path.join(example_dir, lang)
+        os.makedirs(lang_dir, exist_ok=True)
+
+        example_path = os.path.join(lang_dir, example_file)
+
+        if not os.path.exists(example_path):
+            if not self._download_file(
+                    url_template.format(lang=lang),
+                    example_path,
+                    f"examples for [{lang}]"):
+                return []
+
+        logger.info(
+            f"Loading few-shot examples from "
+            f"{os.path.basename(example_path)} for [{lang}]...")
+        try:
+            with open(example_path, "rb") as f:
+                example_po = pofile.read_po(f)
+            examples = [
+                (entry.id, entry.string)
+                for entry in example_po
+                if entry.id and entry.string
+            ]
+            logger.info(
+                f"Loaded {len(examples)} examples for [{lang}].")
+            return examples
+        except Exception as e:
+            logger.warning(
+                f"Error reading example PO file for [{lang}]: {e}")
+            return []
+
+    def load_fixed_examples(self, lang_code, example_dir,
+                            fixed_example_json, example_url, example_file):
+        """Load fixed translation examples from JSON, with PO fallback.
+
+        Tries to load curated examples from a JSON file first.
+        Falls back to the top 2 entries from a PO file on failure.
+
+        Args:
+            lang_code: Language code to process.
+            example_dir: Root directory for example files.
+            fixed_example_json: Fixed examples JSON filename.
+            example_url: Fallback PO download URL template.
+            example_file: Fallback PO filename.
+
+        Returns:
+            list: List of (msgid, msgstr) tuples.
+        """
+        example_path = os.path.join(
+            example_dir, lang_code, fixed_example_json)
+
+        try:
+            with open(example_path, 'r', encoding='utf-8') as f:
+                language_examples = json.load(f)
+
+            if language_examples:
+                logger.info(
+                    f"Loaded {len(language_examples)} fixed examples "
+                    f"from '{example_path}'.")
+                return [
+                    (ex['msgid'], ex['msgstr'])
+                    for ex in language_examples
+                ]
+
+        except FileNotFoundError:
+            logger.warning(
+                f"'{example_path}' not found. Attempting fallback.")
+        except Exception as e:
+            logger.warning(f"Error loading '{example_path}': {e}")
+
+        logger.info(
+            f"Loading default examples (top 2) from "
+            f"'{example_file}' instead.")
+        return self.load_examples(
+            lang_code, example_url, example_file, example_dir)[:2]

--- a/ci/playbooks/roles/prepare-ai-translation/tasks/main.yaml
+++ b/ci/playbooks/roles/prepare-ai-translation/tasks/main.yaml
@@ -175,3 +175,16 @@
   environment:
     PYTHONPATH: "{{ scripts_dir }}"
   register: diff_result
+
+- name: Run AI translation on extracted entries
+  command:
+    argv:
+      - "{{ venv_dir }}/bin/python3"
+      - "{{ scripts_dir }}/translate.py"
+      - "--config"
+      - "{{ config_file }}"
+  args:
+    chdir: "{{ base_dir }}"
+  environment:
+    PYTHONPATH: "{{ scripts_dir }}"
+  when: diff_result.stdout | int > 0


### PR DESCRIPTION
## Related Issue

- PR 계획: #76
- 진행 상황: #77, #78, #79

## Category
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Description

### 변경사항

1. Ansible 플레이북 설정 변경

**`tasks/main.yaml`**
- AI 번역 스크립트(`translate.py`) 실행 태스크 추가

**`defaults/main.yaml`**
- JSON 캐시 변수 (`glossary_json`) 제거
  - `glossary.po` 파일을 JSON으로 캐싱하려고 하였으나, 매번 새로운 워크스페이스가 생성되는 CI 환경 특성상 불필요한 작업이므로 제거

2. AI 번역 파이프라인 로직

**`translate.py`**
- Ollama API 호출 시 `format` 파라미터를 통해 JSON Array 응답을 강제하여 파싱 안정성 확보
- 배치 번역 중 응답 개수 불일치나 파싱 오류가 발생할 경우, 해당 배치의 항목들을 개별 단위로 재시도하는 `Fallback` 로직 추가
- 프롬프트에 전체 언어명을 전달하기 위해 사용하던 하드코딩된 언어 매핑(`LANG_MAP`)을 제거하고, `babel.Locale.get_language_name()`을 활용한 동적 변환으로 대체
- 모델명, 배치 사이즈 등의 하드코딩된 상수를 `config.yaml` 기반의 구조로 리팩토링
- `ThreadPoolExecutor`를 활용하여 배치 번역이 병렬로 처리되도록 구현
- `build_llm_caller`, `create_batches` 등의 함수들을 `AITranslator` 클래스의 정적 메서드로 이동하여 구조 리팩토링

3. 유틸리티 최적화 및 버그 수정

**`utils.py`**
- CI 환경에서는 로컬 JSON 캐시가 무의미하므로, JSON 캐싱 로직 제거
  - 위 과정에서 JSON 로드 실패 시 빈 객체(`{}`)를 반환하던 버그 해결
- AI 번역 스크립트(`translate.py`) 실행에 필요한 유틸리티 추가

### 피드백 반영 (#80 리뷰)

- 기존 논문 작업에서 사용했던 `save_experiment_log` 메서드 및 관련 로직을 `utils.py`, `translate.py`에서 제거